### PR TITLE
add transclusion to quantum-template using {{content}}

### DIFF
--- a/quantum-template/index.js
+++ b/quantum-template/index.js
@@ -3,12 +3,17 @@ var quantum = require('quantum-js')
 function replacer (variables, str) {
   var res = str
   variables.forEach(function (v) {
-    if (typeof (v.value) === 'object') {
-      var val = JSON.stringify(v.value)
+    if (v.key === 'content') {
+      if (res.indexOf('{{' + v.key + '}}') > -1)
+        res = v.value
     } else {
-      var val = v.value
+      if (typeof (v.value) === 'object') {
+        var val = JSON.stringify(v.value)
+      } else {
+        var val = v.value
+      }
+      res = res.replace('{{' + v.key + '}}', val)
     }
-    res = res.replace('{{' + v.key + '}}', val)
   })
   return res
 }
@@ -190,7 +195,8 @@ function applyDefinitions (parsed, definitions) {
     // XXX: add sub-entities name.ps, name.cs, age.ps, age.cs, etc
     var variables = [
       {key: 'ps', value: selection.ps()},
-      {key: 'cs', value: selection.cs()}
+      {key: 'cs', value: selection.cs()},
+      {key: 'content', value: selection.content}
     ]
 
     return template({type: '', ps: [], content: definitions[parsed.type].content}, variables).content

--- a/quantum-template/test/spec.js
+++ b/quantum-template/test/spec.js
@@ -1,188 +1,184 @@
-var chai     = require('chai')
+var chai = require('chai')
 var template = require('..')
 var should = chai.should()
-var quantum  = require('quantum-js')
+var quantum = require('quantum-js')
 
-describe('Template', function() {
+describe('Template', function () {
   // promise friendly version of 'it'
-  function pit(desc, f) {
-    it(desc, function(done){
-      f().then(function(){
+  function pit (desc, f) {
+    it(desc, function (done) {
+      f().then(function () {
         done()
       }).done(null, done)
     })
   }
 
-  function compare(input, source, expected) {
+  function compare (input, source, expected) {
     return quantum.read(source)
       .map(template({variables: input}))
-      .map(function(result) {
+      .map(function (result) {
         return quantum.read(expected)
-          .map(function(expct) {
+          .map(function (expct) {
             result.content.should.eql(expct.content)
           })
       })
   }
 
-  describe('Api', function() {
-
-    it('should return a function when just the options are passed in', function() {
+  describe('Api', function () {
+    it('should return a function when just the options are passed in', function () {
       var options = {}
       template({}).should.not.equal(options)
       template({}).should.be.a.function
     })
   })
 
-
-  describe('Variable Replacement', function() {
-
+  describe('Variable Replacement', function () {
     // basic-content
-    pit('should replace a variable within the content of a entity', function() {
+    pit('should replace a variable within the content of a entity', function () {
       return compare({name: 'Barry'}, 'test/um/basic-content/source.um', 'test/um/basic-content/expected-1.um')
     })
 
-    pit('should replace a variable within the content of a entity with another value', function() {
+    pit('should replace a variable within the content of a entity with another value', function () {
       return compare({name: 'Bob'}, 'test/um/basic-content/source.um', 'test/um/basic-content/expected-2.um')
     })
 
     // basic-params
-    pit('should replace a variable within the params of a entity', function() {
+    pit('should replace a variable within the params of a entity', function () {
       return compare({name: 'Barry'}, 'test/um/basic-params/source.um', 'test/um/basic-params/expected-1.um')
     })
 
-    pit('should replace a variable within the params of a entity with another value', function() {
+    pit('should replace a variable within the params of a entity with another value', function () {
       return compare({name: 'Bob'}, 'test/um/basic-params/source.um', 'test/um/basic-params/expected-2.um')
     })
 
     // multi-content
-    pit('should replace multiple variable with the in the content of a entity', function() {
+    pit('should replace multiple variable with the in the content of a entity', function () {
       return compare({name: 'Barry', named: 'Bob'}, 'test/um/multi-content/source.um', 'test/um/multi-content/expected-1.um')
     })
 
-    pit('should replace muleiplt variable with the in the content of a entity with another value', function() {
+    pit('should replace muleiplt variable with the in the content of a entity with another value', function () {
       return compare({name: 'Bob'}, 'test/um/multi-content/source.um', 'test/um/multi-content/expected-2.um')
     })
 
-    pit('should replace multiple variable with the in the content of a entity with another value', function() {
+    pit('should replace multiple variable with the in the content of a entity with another value', function () {
       return compare({named: 'Bob'}, 'test/um/multi-content/source.um', 'test/um/multi-content/expected-3.um')
     })
 
     // multi-params
-    pit('should replace multiple variables with the in the params of a entity', function() {
+    pit('should replace multiple variables with the in the params of a entity', function () {
       return compare({name: 'Barry', named: 'Bob'}, 'test/um/multi-params/source.um', 'test/um/multi-params/expected-1.um')
     })
 
-    pit('should replace multiple variables with the in the params of a entity with another value', function() {
+    pit('should replace multiple variables with the in the params of a entity with another value', function () {
       return compare({name: 'Bob'}, 'test/um/multi-params/source.um', 'test/um/multi-params/expected-2.um')
     })
 
-    pit('should replace multiple variables with the in the params of a entity with another value', function() {
+    pit('should replace multiple variables with the in the params of a entity with another value', function () {
       return compare({named: 'Bob'}, 'test/um/multi-params/source.um', 'test/um/multi-params/expected-3.um')
     })
 
     // deep-variable
-    pit('should replace a variable with the in the content of a entity', function() {
+    pit('should replace a variable with the in the content of a entity', function () {
       return compare({person: {name: { first: 'Barry'}}}, 'test/um/deep-variable/source.um', 'test/um/deep-variable/expected-1.um')
     })
 
-    pit('should replace a variable with the in the content of a entity with another value', function() {
+    pit('should replace a variable with the in the content of a entity with another value', function () {
       return compare({person: {name: { first: 'Bob'}}}, 'test/um/deep-variable/source.um', 'test/um/deep-variable/expected-2.um')
     })
   })
 
-
-  describe('For Loop', function() {
-
-    pit('should handle for loops with no content', function() {
+  describe('For Loop', function () {
+    pit('should handle for loops with no content', function () {
       return compare({items: ['one', 'two', 'three']}, 'test/um/for-loop/source-empty.um', 'test/um/for-loop/expected-empty.um')
     })
 
-    pit('should handle for loops with basic content', function() {
+    pit('should handle for loops with basic content', function () {
       return compare({items: ['one', 'two', 'three']}, 'test/um/for-loop/source-simple.um', 'test/um/for-loop/expected-simple.um')
     })
 
-    pit('should handle for loops with more entity content', function() {
+    pit('should handle for loops with more entity content', function () {
       return compare({items: ['one', 'two', 'three']}, 'test/um/for-loop/source-advanced.um', 'test/um/for-loop/expected-advanced.um')
     })
 
-    pit('should handle nested for loops with more entity content', function() {
+    pit('should handle nested for loops with more entity content', function () {
       return compare({items: ['one', 'two', 'three'], name: 'bob'}, 'test/um/for-loop/source-nested.um', 'test/um/for-loop/expected-nested.um')
     })
 
-    pit('should handle for loops on objects', function() {
+    pit('should handle for loops on objects', function () {
       return compare({obj: {Bob: 21, Jan: 24, Dan: 16}}, 'test/um/for-loop/source-object.um', 'test/um/for-loop/expected-object.um')
     })
 
-    pit('should throw when the wrong syntax is used', function() {
+    pit('should throw when the wrong syntax is used', function () {
       return quantum.read('test/um/for-loop/source-incomplete.um')
         .then(template({}))
-        .then(function(res){
+        .then(function (res) {
           res.should.not.be.defined
         })
-        .catch(function(err){
+        .catch(function (err) {
           err.should.be.defined
         })
     })
 
   })
 
-
-  describe('If Statements', function() {
-
-    pit('should handle if with no content', function() {
+  describe('If Statements', function () {
+    pit('should handle if with no content', function () {
       return compare({}, 'test/um/if/source-empty.um', 'test/um/if/expected-empty.um')
     })
 
-    pit('should handle if with no content', function() {
+    pit('should handle if with no content', function () {
       return compare({}, 'test/um/if/source-invalid.um', 'test/um/if/expected-empty.um')
     })
 
-    pit('should handle if with basic content: true', function() {
+    pit('should handle if with basic content: true', function () {
       return compare({'public': true}, 'test/um/if/source-simple.um', 'test/um/if/expected-nonempty.um')
     })
 
-    pit('should handle if with basic content: false', function() {
+    pit('should handle if with basic content: false', function () {
       return compare({'public': false}, 'test/um/if/source-simple.um', 'test/um/if/expected-empty.um')
     })
 
-    pit('should handle if with basic content: undefined', function() {
+    pit('should handle if with basic content: undefined', function () {
       return compare({}, 'test/um/if/source-simple.um', 'test/um/if/expected-empty.um')
     })
 
-    pit('should handle if with nested key', function() {
+    pit('should handle if with nested key', function () {
       return compare({site: {'public': true}}, 'test/um/if/source-subproperty.um', 'test/um/if/expected-nonempty.um')
     })
 
   })
 
-
-  describe('Ifnot Statements', function() {
-
-    pit('should handle ifnot with no content', function() {
+  describe('Ifnot Statements', function () {
+    pit('should handle ifnot with no content', function () {
       return compare({}, 'test/um/ifnot/source-empty.um', 'test/um/ifnot/expected-empty.um')
     })
 
-    pit('should handle ifnot with no content', function() {
+    pit('should handle ifnot with no content', function () {
       return compare({}, 'test/um/ifnot/source-invalid.um', 'test/um/ifnot/expected-nonempty.um')
     })
 
-    pit('should handle ifnot with basic content: true', function() {
+    pit('should handle ifnot with basic content: true', function () {
       return compare({'public': true}, 'test/um/ifnot/source-simple.um', 'test/um/ifnot/expected-empty.um')
     })
 
-    pit('should handle ifnot with basic content: false', function() {
+    pit('should handle ifnot with basic content: false', function () {
       return compare({'public': false}, 'test/um/ifnot/source-simple.um', 'test/um/ifnot/expected-nonempty.um')
     })
 
-    pit('should handle ifnot with basic content: undefined', function() {
+    pit('should handle ifnot with basic content: undefined', function () {
       return compare({}, 'test/um/ifnot/source-simple.um', 'test/um/ifnot/expected-nonempty.um')
     })
 
-    pit('should handle ifnot with nested key', function() {
+    pit('should handle ifnot with nested key', function () {
       return compare({site: {'public': true}}, 'test/um/ifnot/source-subproperty.um', 'test/um/ifnot/expected-empty.um')
     })
 
   })
 
+  describe('transclude', function () {
+    pit('should transclude {{content}} correctly', function () {
+      return compare({}, 'test/um/transclude/source.um', 'test/um/transclude/expected.um')
+    })
+  })
 
 })

--- a/quantum-template/test/um/transclude/expected.um
+++ b/quantum-template/test/um/transclude/expected.um
@@ -1,0 +1,7 @@
+Top Text: Test 1
+Middle Text
+Bottom Text
+Top Text: Test 2
+@p: Paragraph
+@div: div
+Bottom Text

--- a/quantum-template/test/um/transclude/source.um
+++ b/quantum-template/test/um/transclude/source.um
@@ -1,0 +1,8 @@
+@define transcludeTest
+  Top Text: {{ps}}
+  {{content}}
+  Bottom Text
+@transcludeTest Test 1: Middle Text
+@transcludeTest Test 2
+  @p: Paragraph
+  @div: div


### PR DESCRIPTION
The more I think about quantum-template, the more I think that it would be more useful to be able to make a page layout template and just dump in content.

With the changes, the following would is possible:

Template:

```
@define page
  @topSection
    @breadcrumb
      @item /: Home
    @title {{ps}}

  @contentSection
    {{content}}
```

Use:

```
@page Page
  @div: Some content in a div
  @div: some content in another div
    @div: some nested content
```

Result (equivalent):

```
@topSection
  @breadcrumb
    @item /: Home
  @title Page

@contentSection
  @div: Some content in a div
  @div: some content in another div
    @div: some nested content
```
