### PR TITLE
Firefox style fix for quantum-api

### DIFF
--- a/quantum-api/client/quantum-api.css
+++ b/quantum-api/client/quantum-api.css
@@ -56,16 +56,18 @@
   flex-shrink: 0;
 }
 
-.qm-api-chevron-icon {
+.qm-api-chevron-icon:before {
+  display: inline-block;
+  line-height: 0;
   content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="14" viewBox="0 0 10 14"><path fill="%23FFF" d="M8.648 6.852L2.85 12.65q-.147.147-.35.147t-.353-.148L.85 11.35Q.702 11.204.702 11t.148-.352L4.998 6.5.85 2.352Q.702 2.204.702 2t.148-.352L2.147.35Q2.295.204 2.5.204t.35.148L8.65 6.15q.148.148.148.352t-.148.352z"/></svg>')
 }
 
-.qm-api-collapsible-toggle .qm-api-chevron-icon {
+.qm-api-collapsible-toggle .qm-api-chevron-icon:before; {
   transition: -webkit-transform 0.2s;
   transition: transform 0.2s;
 }
 
-.qm-api-collapsible-open > .qm-api-collapsible-heading .qm-api-chevron-icon {
+.qm-api-collapsible-open > .qm-api-collapsible-heading .qm-api-chevron-icon:before {
   -webkit-transform: rotate(90deg);
   transform: rotate(90deg);
 }


### PR DESCRIPTION
I noticed an issue with the chevrons in firefox that was due to the chevrons being added as `content` inside an element directly instead of inside a pseudo element (e.g. `:before`)
I've resolved this and tweaked the styles so that they display correctly.
