### PR TITLE
Add handling to the watch api function to build unwatched files

### DIFF
--- a/quantum-js/lib/file-options.js
+++ b/quantum-js/lib/file-options.js
@@ -87,7 +87,7 @@ function normalizeSpec (item) {
     return {
       files: files,
       base: item.base ? item.base : inferBase(item.files), // in the 'else' situation item.files must be a string since it passed the validation check
-      watch: item.watch,
+      watch: item.watch !== false,
       dest: item.dest
     }
   }


### PR DESCRIPTION
Resolves #109 (hopefully)

## Example setup
**Files:**
```
src/
 - pages/
    - index.um
    - unwatched.um
```

**quantum.config.js**
```js
const html = require('quantum-html')

const htmlTransforms = {
  html: html.transforms()
}

module.exports = {
  htmlTransforms: htmlTransforms,
  pipeline: [
    html.fileTransform()
  ],
  pages: ...
}
```

**Command:**
```
quantum watch --port=9090
```

### Example 1 (explictly unwatched)
```js
pages: [
    {
      files: ['src/pages/index.um'],
      base: 'src/pages',
      watch: true
    },
    {
      files: ['src/pages/unwatched.um'],
      base: 'src/pages',
      watch: false
    }
  ]
```

```
Starting Server
http://0.0.0.0:9090

Copying Resources

Building Unwatched Files
src/pages/unwatched.um [10 ms] -> 1 page

Built 1 pages [0.02 s]

Building Watched Files
src/pages/index.um [2 ms] -> 1 page
```

### Example 2 (default true for watched)
All these produce the same console output
```js
pages: [
    {
      files: ['src/pages/index.um'],
      base: 'src/pages',
      watch: true
    },
    {
      files: ['src/pages/unwatched.um'],
      base: 'src/pages'
    }
  ]
```
```js
pages: ['src/pages/index.um', 'src/pages/unwatched.um'] // Files go to target/src/pages but rest the same
```
```js
pages: {
    files: ['src/pages/index.um', 'src/pages/unwatched.um'],
    base: 'src/pages'
  }
```

```
Starting Server
http://0.0.0.0:9090

Copying Resources

Building Watched Files
src/pages/index.um [9 ms] -> 1 page
src/pages/unwatched.um [1 ms] -> 1 page
```