### PR TITLE
make the `@head` entity work correctly by handling nested arrays correctly

### DIFF
--- a/quantum-html/lib/index.js
+++ b/quantum-html/lib/index.js
@@ -164,6 +164,10 @@ function standardDefaultTransform (selection) {
   return quantum.isSelection(selection) ? selection.cs() : selection
 }
 
+function flatten (arrays) {
+  return Array.prototype.concat.apply([], arrays)
+}
+
 /*
   Returns the transform function that converts parsed quantum source to virtual dom.
 */
@@ -191,7 +195,8 @@ function buildDOM (options) {
   return (file) => {
     return Promise.resolve(quantum.select(file.content).transform(transformer))
       .then((elements) => {
-        const completeElements = includeCommonMetaTags ? elements.concat(commonMetaTags) : elements
+        const flattenedElements = flatten(elements)
+        const completeElements = includeCommonMetaTags ? flattenedElements.concat(commonMetaTags) : flattenedElements
         return file.clone({
           content: new HTMLPage(completeElements)
         })


### PR DESCRIPTION
Currently, using `@head` creates an array of items that is then passed to the `extractTypes` function and not handled, resulting in favicons being ignored in some situations.

### Example
```
@head
  @link
    @attr rel: apple-touch-icon
    @attr sizes: 57x57
    @attr href: /resources/favicons/apple-touch-icon-57x57.png
```
Results in:
```js
[ [ HeadWrapper { element: [Object], options: {} } ], // The nested array causing issues
  HeadWrapper {
    element: Element { type: 'meta', attrs: [Object], content: [], endContent: [] },
    options: {} } ]
```

I'm not sure if this is the correct way to resolve the issue or whether it should be fixed where the array is created?