### PR TITLE
fix(*): Fixed a bunch of bugs that I ran into whilst re-writing the hexagon docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,2064 @@
+{
+  "name": "quantum-site",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "autolinker": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "compressible": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+      "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "compression": {
+      "version": "1.7.2",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+      "requires": {
+        "accepts": "1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "2.0.13",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
+      }
+    },
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "1.3.2",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dagre": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.7.4.tgz",
+      "integrity": "sha1-3nLw50pVDOEc5jjwoTb+1xI5gCI=",
+      "dev": true,
+      "requires": {
+        "graphlib": "1.0.7",
+        "lodash": "3.10.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "requires": {
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graphlib": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-1.0.7.tgz",
+      "integrity": "sha1-DKst8P/mq+BwsmJb+h7bbslnuLE=",
+      "dev": true,
+      "requires": {
+        "lodash": "3.10.1"
+      }
+    },
+    "gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+      "requires": {
+        "ansi-red": "0.1.1",
+        "coffee-script": "1.12.7",
+        "extend-shallow": "2.0.1",
+        "js-yaml": "3.11.0",
+        "toml": "2.3.3"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        }
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "requires": {
+        "set-getter": "0.1.0"
+      }
+    },
+    "list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "extend-shallow": "2.0.1",
+        "is-number": "2.1.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
+    "markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88="
+    },
+    "markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "requires": {
+        "concat-stream": "1.6.1",
+        "diacritics-map": "0.1.0",
+        "gray-matter": "2.1.1",
+        "lazy-cache": "2.0.2",
+        "list-item": "1.1.1",
+        "markdown-link": "0.1.1",
+        "minimist": "1.2.0",
+        "mixin-deep": "1.3.1",
+        "object.pick": "1.3.0",
+        "remarkable": "1.7.1",
+        "repeat-string": "1.6.1",
+        "strip-color": "0.1.0"
+      }
+    },
+    "marked": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
+      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ=="
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "optional": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "quantum-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-api/-/quantum-api-2.0.0.tgz",
+      "integrity": "sha1-PWRW9xToWd2sgpC4+lMWzCLNGOg=",
+      "dev": true,
+      "requires": {
+        "quantum-core": "2.0.0",
+        "quantum-dom": "2.0.0",
+        "quantum-html": "2.0.0",
+        "quantum-version": "2.0.0"
+      }
+    },
+    "quantum-code-highlight": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-code-highlight/-/quantum-code-highlight-2.0.0.tgz",
+      "integrity": "sha1-IeaSg89wMxMa/GwPEVbLKDmX3QA=",
+      "requires": {
+        "highlight.js": "9.12.0",
+        "quantum-core": "2.0.0",
+        "quantum-dom": "2.0.0"
+      }
+    },
+    "quantum-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-core/-/quantum-core-2.0.0.tgz",
+      "integrity": "sha1-8/vWElhqLYy0gCySdVYbcOfmQDg=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "compression": "1.7.2",
+        "connect": "3.6.6",
+        "flatten": "1.0.2",
+        "fs-extra": "1.0.0",
+        "globby": "6.1.0",
+        "merge": "1.2.0",
+        "serve-static": "1.13.2",
+        "ws": "1.1.5"
+      }
+    },
+    "quantum-diagram": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/quantum-diagram/-/quantum-diagram-2.0.1.tgz",
+      "integrity": "sha1-0rGaLAKA7Ubvg8iDDRXzp+bu2kk=",
+      "dev": true,
+      "requires": {
+        "dagre": "0.7.4",
+        "quantum-core": "2.0.0",
+        "quantum-dom": "2.0.0"
+      }
+    },
+    "quantum-docs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-docs/-/quantum-docs-2.0.0.tgz",
+      "integrity": "sha1-EURQgvgQpTsmaa4AClvymJUz0mI=",
+      "dev": true,
+      "requires": {
+        "quantum-core": "2.0.0",
+        "quantum-dom": "2.0.0",
+        "quantum-html": "2.0.0"
+      }
+    },
+    "quantum-dom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-dom/-/quantum-dom-2.0.0.tgz",
+      "integrity": "sha1-UfNQO1zFz10FQoAoRoQGDE6nKQ8=",
+      "requires": {
+        "bluebird": "3.5.1"
+      }
+    },
+    "quantum-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-html/-/quantum-html-2.0.0.tgz",
+      "integrity": "sha1-ZZf45em80DuhhuwTnnG0Hm4OiKs=",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "bluebird": "3.5.1",
+        "merge": "1.2.0",
+        "quantum-core": "2.0.0",
+        "quantum-dom": "2.0.0"
+      },
+      "dependencies": {
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        }
+      }
+    },
+    "quantum-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-markdown/-/quantum-markdown-2.0.0.tgz",
+      "integrity": "sha1-kg2FSzvVTgHCUsE7b0qXWOrNMtY=",
+      "requires": {
+        "markdown-toc": "1.2.0",
+        "marked": "0.3.17",
+        "quantum-code-highlight": "2.0.0",
+        "quantum-core": "2.0.0",
+        "quantum-dom": "2.0.0"
+      }
+    },
+    "quantum-template": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-template/-/quantum-template-2.0.0.tgz",
+      "integrity": "sha1-vhlMLJtW0cWSJig/57yJVjrSeBU=",
+      "dev": true,
+      "requires": {
+        "quantum-core": "2.0.0"
+      }
+    },
+    "quantum-version": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quantum-version/-/quantum-version-2.0.0.tgz",
+      "integrity": "sha1-ksLfMuv/VbKU1+qlRKo6wy6JaBs=",
+      "dev": true,
+      "requires": {
+        "quantum-core": "2.0.0"
+      }
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "readable-stream": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.5",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "remarkable": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+      "requires": {
+        "argparse": "0.1.16",
+        "autolinker": "0.15.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+          "requires": {
+            "underscore": "1.7.0",
+            "underscore.string": "2.4.0"
+          }
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "toml": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,15 +16,13 @@
     "bluebird": "^3.1.1",
     "quantum-api": "^2.0.0",
     "quantum-code-highlight": "^2.0.0",
+    "quantum-diagram": "^2.0.0",
     "quantum-docs": "^2.0.0",
     "quantum-dom": "^2.0.0",
     "quantum-html": "^2.0.0",
+    "quantum-markdown": "^2.0.0",
     "quantum-template": "^2.0.0",
-    "quantum-version": "^2.0.0",
-    "quantum-diagram": "^2.0.0"
+    "quantum-version": "^2.0.0"
   },
-  "private": true,
-  "dependencies": {
-    "quantum-markdown": "^2.0.0"
-  }
+  "private": true
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,5 +23,8 @@
     "quantum-version": "^2.0.0",
     "quantum-diagram": "^2.0.0"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "quantum-markdown": "^2.0.0"
+  }
 }

--- a/docs/src/pages/docs/modules/quantum-api/api/entities.um
+++ b/docs/src/pages/docs/modules/quantum-api/api/entities.um
@@ -147,6 +147,11 @@
               @reverseVisibleList true
 
     @entity process
+      @bugfix 2.0.1
+        @description
+          Resolved an issue where the changelog tried to process all tags for
+          all api groups
+
       @description
         Define the api content to process.
 
@@ -199,6 +204,59 @@
         @@um
           @property propertyName
             @description: Description of property
+
+  @entity added
+    @added 2.0.0
+    @description
+      Display an added tag on the API entry. Useful
+
+    @param version
+      @description
+        The version for the change. Use in conjunction with
+        @code[quantum-version]
+
+  @entity updated
+    @added 2.0.0
+    @description
+      Display an updated tag on the API entry. Useful
+
+    @param version
+      @description
+        The version for the change. Use in conjunction with
+        @code[quantum-version]
+
+  @entity bugfix
+    @added 2.0.0
+    @bugfix 2.0.1
+      @description
+        Resolved an issue where the bugfix icon did not display in the changelog
+    @description
+      Display an bugfix tag on the API entry. Useful
+
+    @param version
+      @description
+        The version for the change. Use in conjunction with
+        @code[quantum-version]
+
+  @entity deprecated
+    @added 2.0.0
+    @description
+      Display an deprecated tag on the API entry. Useful
+
+    @param version
+      @description
+        The version for the change. Use in conjunction with
+        @code[quantum-version]
+
+  @entity removed
+    @added 2.0.0
+    @description
+      Display an removed tag on the API entry. Useful
+
+    @param version
+      @description
+        The version for the change. Use in conjunction with
+        @code[quantum-version]
 
   @entity extra
     @added 2.0.0

--- a/docs/src/pages/docs/modules/quantum-api/changelog.um
+++ b/docs/src/pages/docs/modules/quantum-api/changelog.um
@@ -1,7 +1,7 @@
 @inline /templates/sidebar-page.um
 
 @topSection
-  @title API changelog
+  @title quantum-api changelog
   @source [https://github.com/ocadotechnology/quantumjs/tree/master/docs/{{filename}}]: Edit Page
   @description
     What has changed in @code[quantum-api] for each release.
@@ -13,10 +13,17 @@
     @process
       @inline entities.um
       @inline api.um
+
+    @version 2.0.1
+      @link {{baseurl}}/docs/modules/quantum-api/2.0.1
+      @description
+        Resolved some bugs that were affecting changelogs and api notices
+
     @version 2.0.0
       @link {{baseurl}}/docs/modules/quantum-api/2.0.0
       @description
         Initial public release of quantum-api.
+
     @version 1.0.0
       @description
         Version 1.0.0 is an unsupported version of the library.

--- a/docs/src/pages/docs/modules/quantum-api/index.um
+++ b/docs/src/pages/docs/modules/quantum-api/index.um
@@ -2,6 +2,7 @@
 
 @versionedPage
   @version 2.0.0
+  @version 2.0.1
 
 @topSection
   @title quantum-api

--- a/docs/src/pages/docs/modules/quantum-core/api/api.um
+++ b/docs/src/pages/docs/modules/quantum-core/api/api.um
@@ -1,5 +1,11 @@
 @object api
   @added 2.0.0
+  @bugfix 2.0.1
+    @description
+      De-duplicated the static files that are written to the disc to prevent
+      static quantum assets being written multiple times and speed up the
+      build/watch process
+
   @description
     This object exposes the functionality that the CLI provides as an api that
     can be called from within your own code.

--- a/docs/src/pages/docs/modules/quantum-core/changelog.um
+++ b/docs/src/pages/docs/modules/quantum-core/changelog.um
@@ -12,10 +12,17 @@
     @reverseVisibleList true
     @process
       @inline api.um
+    @version 2.0.1
+      @link {{baseurl}}/docs/modules/quantum-core/2.0.1
+      @description
+        Reduced the number of times static resources are written when building
+        versioned content
+
     @version 2.0.0
       @link {{baseurl}}/docs/modules/quantum-core/2.0.0
       @description
         Initial public release of quantum-core.
+
     @version 1.0.0
       @description
         Version 1.0.0 is an unsupported version of the library.

--- a/docs/src/pages/docs/modules/quantum-core/index.um
+++ b/docs/src/pages/docs/modules/quantum-core/index.um
@@ -2,6 +2,7 @@
 
 @versionedPage
   @version 2.0.0
+  @version 2.0.1
 
 @topSection
   @title quantum-core

--- a/docs/src/pages/docs/modules/quantum-html/api.um
+++ b/docs/src/pages/docs/modules/quantum-html/api.um
@@ -12,3 +12,4 @@
   @inline api/paragraphTransform.um
   @inline api/prepareTransforms.um
   @inline api/entityTransforms.um
+  @inline api/assets.um

--- a/docs/src/pages/docs/modules/quantum-html/api/assets.um
+++ b/docs/src/pages/docs/modules/quantum-html/api/assets.um
@@ -1,0 +1,12 @@
+@object assets
+  @added 2.1.0
+    @description
+      An object which contains the assets for the html module
+
+  @property css [Asset]
+    @description
+      This asset contains the css required for the quantum-html module.
+
+      This asset is added when the paragraphTransform is used on a page. Normally
+      you won't need to use this asset - its exposed mainly for when writing tests
+      with the html module

--- a/docs/src/pages/docs/modules/quantum-html/changelog.um
+++ b/docs/src/pages/docs/modules/quantum-html/changelog.um
@@ -13,6 +13,13 @@
     @process
       @inline api.um
       @inline entities.um
+
+    @version 2.1.0
+      @link {{baseurl}}/docs/modules/quantum-html/2.1.0
+      @description
+        Expose the css asset to allow transforms in other modules (as well as
+        custom transforms) to easily use the @code[paragraphTransform]
+
     @version 2.0.0
       @link {{baseurl}}/docs/modules/quantum-html/2.0.0
       @description

--- a/docs/src/pages/docs/modules/quantum-html/index.um
+++ b/docs/src/pages/docs/modules/quantum-html/index.um
@@ -2,6 +2,7 @@
 
 @versionedPage
   @version 2.0.0
+  @version 2.1.0
 
 @topSection
   @title quantum-html

--- a/docs/src/pages/docs/modules/quantum-version/api/entities.um
+++ b/docs/src/pages/docs/modules/quantum-version/api/entities.um
@@ -129,6 +129,39 @@
   @arg version
     The version when the content was updated
 
+@entity bugfix
+  @added 2.1.0
+    @description
+      Added the bugfix to match the tags that are available in quantum-api
+  @description
+    This tag has no real affect on the content that is output, but when other
+    modules are used, such as quantum-api, this tag can have an affect on the
+    visible output. A notice will be displayed for @italic[just] the version
+    specified. The content for the notice will be taken from the
+    @type[@description] tag.
+
+    @example
+      @file
+        @@um
+          @versionedPage
+            @version 2.0.0
+
+          @api
+            @function myFunction
+              @bugfix 2.0.0
+                @description
+                  The content of the description block will be shown in the api
+                  section.
+              @arg a [Number]
+              @arg b [number]
+              @return Number
+
+    The automatic changelog generation in quantum-api also uses these tags to
+    build up a summary of what has changed from one version to the next.
+
+  @arg version
+    The version for the bugfix
+
 @entity versionedPage
   @added 2.0.0
 

--- a/docs/src/pages/docs/modules/quantum-version/changelog.um
+++ b/docs/src/pages/docs/modules/quantum-version/changelog.um
@@ -12,6 +12,12 @@
     @reverseVisibleList true
     @process
       @inline api.um
+    @version 2.1.0
+      @link {{baseurl}}/docs/modules/quantum-version/2.1.0
+      @description
+        Fixed an inconsistency between the tags used here and those
+        available in quantum-api
+
     @version 2.0.0
       @link {{baseurl}}/docs/modules/quantum-version/2.0.0
       @description

--- a/docs/src/pages/docs/modules/quantum-version/index.um
+++ b/docs/src/pages/docs/modules/quantum-version/index.um
@@ -2,6 +2,7 @@
 
 @versionedPage
   @version 2.0.0
+  @version 2.1.0
 
 @topSection
   @title quantum-version

--- a/quantum-api/assets/languages/quantum-api-javascript.css
+++ b/quantum-api/assets/languages/quantum-api-javascript.css
@@ -211,10 +211,6 @@
   content: '.';
 }
 
-.qm-changelog-javascript-function .qm-api-javascript-header-function-args {
-  opacity: 0.7;
-}
-
 .qm-changelog-javascript-prototype + .qm-changelog-javascript-method:before {
   content: '::';
 }

--- a/quantum-api/assets/languages/quantum-api-javascript.css
+++ b/quantum-api/assets/languages/quantum-api-javascript.css
@@ -198,6 +198,10 @@
 }
 
 /* Changelog */
+.qm-changelog-javascript-function + .qm-changelog-javascript-arg:before,
+.qm-changelog-javascript-constructor + .qm-changelog-javascript-arg:before,
+.qm-changelog-javascript-method + .qm-changelog-javascript-arg:before,
+.qm-changelog-javascript-arg + .qm-changelog-javascript-property:before,
 .qm-changelog-javascript-prototype + .qm-changelog-javascript-constructor:before,
 .qm-changelog-javascript-prototype + .qm-changelog-javascript-property:before,
 .qm-changelog-javascript-property + .qm-changelog-javascript-property:before,
@@ -205,6 +209,10 @@
 .qm-changelog-javascript-object + .qm-changelog-javascript-function:before,
 .qm-changelog-javascript-object + .qm-changelog-javascript-prototype:before {
   content: '.';
+}
+
+.qm-changelog-javascript-function .qm-api-javascript-header-function-args {
+  opacity: 0.7;
 }
 
 .qm-changelog-javascript-prototype + .qm-changelog-javascript-method:before {

--- a/quantum-api/assets/quantum-changelog-icons.css
+++ b/quantum-api/assets/quantum-changelog-icons.css
@@ -28,7 +28,7 @@
   content: "\e419";
 }
 
-.qm-changelog-icon-bug-fix:before {
+.qm-changelog-icon-bugfix:before {
   content: "\e868";
 }
 

--- a/quantum-api/assets/quantum-changelog.css
+++ b/quantum-api/assets/quantum-changelog.css
@@ -89,6 +89,10 @@
   padding: 0.5em;
 }
 
+.qm-changelog-entry-header:empty {
+  display: none;
+}
+
 .qm-changelog-entry-header .qm-api-item-header {
   display: inline-block;
 }

--- a/quantum-api/lib/entity-transforms/builders/notice.js
+++ b/quantum-api/lib/entity-transforms/builders/notice.js
@@ -7,14 +7,13 @@ module.exports = function createNoticeBuilder (type, title) {
   return (selection, transformer) => {
     if (selection.has(type)) {
       const notice = selection.select(type)
+      const description = notice.select('description')
 
-      if (notice.hasContent()) {
+      if (description.hasContent()) {
         return dom.create('div').class('qm-api-notice qm-api-notice-' + type)
           .add(dom.create('div').class('qm-api-notice-header').text(title))
           .add(dom.create('div').class('qm-api-notice-body')
-            .add(notice
-              .filter(t => t.type !== 'issue')
-              .transform(transformer))
+            .add(description.transform(transformer))
         )
       }
     }

--- a/quantum-api/lib/entity-transforms/builders/notice.js
+++ b/quantum-api/lib/entity-transforms/builders/notice.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const dom = require('quantum-dom')
+const html = require('quantum-html')
 
 /* Creates a new notice builder */
 module.exports = function createNoticeBuilder (type, title) {
@@ -13,7 +14,7 @@ module.exports = function createNoticeBuilder (type, title) {
         return dom.create('div').class('qm-api-notice qm-api-notice-' + type)
           .add(dom.create('div').class('qm-api-notice-header').text(title))
           .add(dom.create('div').class('qm-api-notice-body')
-            .add(description.transform(transformer))
+            .add(html.paragraphTransform(description, transformer))
         )
       }
     }

--- a/quantum-api/lib/file-transforms/changelog.js
+++ b/quantum-api/lib/file-transforms/changelog.js
@@ -204,7 +204,7 @@ function buildEntries (version, versions, tagSelections, entityTypeToLanguage) {
         if (selection.type() === 'group') {
           selection = selection.parent()
         } else {
-          const selType = selection.type().replace('?','')
+          const selType = selection.type().replace('?', '')
           // If we hit something that is not supported by the language, then quit
           if (entityTypeToLanguage[selType] !== language) {
             return

--- a/quantum-api/lib/file-transforms/changelog.js
+++ b/quantum-api/lib/file-transforms/changelog.js
@@ -97,7 +97,9 @@ function buildChangelogs (changelogList, entityTypeToLanguage, groupByApi) {
       tagSelectionsByVersion[version]
         .filter(tag => tag.type() === 'deprecated')
         .forEach(tag => {
-          if (tag.parent().has('removed') && tag.parent().select('removed').ps() !== nextVersion) {
+          const parentHasRemoved = tag.parent().has('removed')
+          const parentRemovedInNextVersion = parentHasRemoved && tag.parent().select('removed').ps() === nextVersion
+          if (!parentHasRemoved || !parentRemovedInNextVersion) {
             tagSelectionsByVersion[nextVersion].push(tag)
           }
         })
@@ -143,7 +145,7 @@ function buildGroups (version, versions, tagSelections, entityTypeToLanguage) {
     return {
       type: 'group',
       params: [apiName],
-      content: buildEntries(version, versions, tagSelections, entityTypeToLanguage)
+      content: buildEntries(version, versions, tags, entityTypeToLanguage)
     }
   })
 }
@@ -158,18 +160,30 @@ function buildEntries (version, versions, tagSelections, entityTypeToLanguage) {
   })
 
   const res = []
-  Array.from(tagsByParent.entries()).forEach(([parent, tagSelections]) => {
+  Array.from(tagsByParent.entries()).forEach(([parent, tagsForApi]) => {
+    // Generate the changes for an api
     if (parent.type() === 'api') {
-      tagSelections.forEach(tag => {
+      tagsForApi.forEach(tag => {
         const content = tag.content()
         if (!tag.has('description') && parent.has('description') && tag.type() === 'added') {
           content.push(quantum.clone(parent.select('description').entity()))
         }
-        res.push({
+
+        const change = {
           type: 'change',
           params: [tag.type()],
           content: content
-        })
+        }
+
+        if (tag.parent() === parent) {
+          res.push({
+            type: 'entry',
+            params: [],
+            content: [change]
+          })
+        } else {
+          res.push(change)
+        }
       })
     } else {
       const language = entityTypeToLanguage[parent.type()]
@@ -190,12 +204,13 @@ function buildEntries (version, versions, tagSelections, entityTypeToLanguage) {
         if (selection.type() === 'group') {
           selection = selection.parent()
         } else {
+          const selType = selection.type().replace('?','')
           // If we hit something that is not supported by the language, then quit
-          if (entityTypeToLanguage[selection.type()] !== language) {
+          if (entityTypeToLanguage[selType] !== language) {
             return
           }
           entity = {
-            type: selection.type(),
+            type: selType,
             params: selection.params().slice(),
             content: entity ? [entity] : sanitizedParent.content()
           }
@@ -213,7 +228,7 @@ function buildEntries (version, versions, tagSelections, entityTypeToLanguage) {
         res.push({
           type: 'entry',
           params: [],
-          content: [header].concat(tagSelections.map(tag => {
+          content: [header].concat(tagsForApi.map(tag => {
             const content = tag.content()
             if (!tag.has('description') && parent.has('description') && tag.type() === 'added') {
               content.push(quantum.clone(parent.select('description').entity()))
@@ -228,7 +243,6 @@ function buildEntries (version, versions, tagSelections, entityTypeToLanguage) {
       }
     }
   })
-
   return res
 }
 

--- a/quantum-api/lib/languages/javascript.js
+++ b/quantum-api/lib/languages/javascript.js
@@ -284,6 +284,10 @@ module.exports = (options) => {
     'function': {
       header: typeHeaderBuilders['function']
     },
+    'arg': {
+      header: typeHeaderBuilders.arg,
+      renderAsOther: { Function: typeHeaderBuilders['function'], Object: typeHeaderBuilders.object }
+    },
     'method': {
       header: typeHeaderBuilders.method
     },

--- a/quantum-api/lib/languages/javascript.js
+++ b/quantum-api/lib/languages/javascript.js
@@ -288,6 +288,10 @@ module.exports = (options) => {
       header: typeHeaderBuilders.arg,
       renderAsOther: { Function: typeHeaderBuilders['function'], Object: typeHeaderBuilders.object }
     },
+    'arg?': {
+      header: typeHeaderBuilders.arg,
+      renderAsOther: { Function: typeHeaderBuilders['function'], Object: typeHeaderBuilders.object }
+    },
     'method': {
       header: typeHeaderBuilders.method
     },

--- a/quantum-api/test/entity-transforms/builders/item.spec.js
+++ b/quantum-api/test/entity-transforms/builders/item.spec.js
@@ -60,7 +60,17 @@ describe('item', () => {
       type: 'function',
       params: [],
       content: [
-        {type: 'deprecated', params: [], content: ['Warning']}
+        {
+          type: 'deprecated',
+          params: [],
+          content: [
+            {
+              type: 'description',
+              params: [],
+              content: ['Warning']
+            }
+          ]
+        }
       ]
     })
 

--- a/quantum-api/test/entity-transforms/builders/notice.spec.js
+++ b/quantum-api/test/entity-transforms/builders/notice.spec.js
@@ -3,13 +3,8 @@ describe('notice', () => {
   const path = require('path')
   const quantum = require('quantum-core')
   const dom = require('quantum-dom')
+  const html = require('quantum-html')
   const notice = require('../../../lib/entity-transforms/builders/notice')
-
-  const paragraphAsset = dom.asset({
-    url: '/quantum-html.css',
-    filename: path.join(__dirname, '../../../node_modules/quantum-html/assets/quantum-html.css'),
-    shared: true
-  })
 
   it('renders nothing if there is no notice', () => {
     const selection = quantum.select({
@@ -60,7 +55,7 @@ describe('notice', () => {
       dom.create('div').class('qm-api-notice qm-api-notice-removed')
         .add(dom.create('div').class('qm-api-notice-header').add('Removed'))
         .add(dom.create('div').class('qm-api-notice-body')
-          .add(paragraphAsset)
+          .add(html.asset)
           .add(dom.create('div').class('qm-html-paragraph')
             .add(dom.textNode('Hi '))))
     )

--- a/quantum-api/test/entity-transforms/builders/notice.spec.js
+++ b/quantum-api/test/entity-transforms/builders/notice.spec.js
@@ -1,8 +1,15 @@
 describe('notice', () => {
   const should = require('chai').should()
+  const path = require('path')
   const quantum = require('quantum-core')
   const dom = require('quantum-dom')
   const notice = require('../../../lib/entity-transforms/builders/notice')
+
+  const paragraphAsset = dom.asset({
+    url: '/quantum-html.css',
+    filename: path.join(__dirname, '../../../../quantum-html/assets/quantum-html.css'),
+    shared: true
+  })
 
   it('renders nothing if there is no notice', () => {
     const selection = quantum.select({
@@ -31,7 +38,17 @@ describe('notice', () => {
       type: '',
       params: [],
       content: [
-        {type: 'removed', params: [], content: ['Hi']}
+        {
+          type: 'removed',
+          params: [],
+          content: [
+            {
+              type: 'description',
+              params: [],
+              content: ['Hi']
+            }
+          ]
+        }
       ]
     })
 
@@ -42,7 +59,10 @@ describe('notice', () => {
     notice('removed', 'Removed')(selection, transformer).should.eql(
       dom.create('div').class('qm-api-notice qm-api-notice-removed')
         .add(dom.create('div').class('qm-api-notice-header').add('Removed'))
-        .add(dom.create('div').class('qm-api-notice-body').add('Hi'))
+        .add(dom.create('div').class('qm-api-notice-body')
+          .add(paragraphAsset)
+          .add(dom.create('div').class('qm-html-paragraph')
+            .add(dom.textNode('Hi '))))
     )
   })
 })

--- a/quantum-api/test/entity-transforms/builders/notice.spec.js
+++ b/quantum-api/test/entity-transforms/builders/notice.spec.js
@@ -55,7 +55,7 @@ describe('notice', () => {
       dom.create('div').class('qm-api-notice qm-api-notice-removed')
         .add(dom.create('div').class('qm-api-notice-header').add('Removed'))
         .add(dom.create('div').class('qm-api-notice-body')
-          .add(html.asset)
+          .add(html.assets.css)
           .add(dom.create('div').class('qm-html-paragraph')
             .add(dom.textNode('Hi '))))
     )

--- a/quantum-api/test/entity-transforms/builders/notice.spec.js
+++ b/quantum-api/test/entity-transforms/builders/notice.spec.js
@@ -7,7 +7,7 @@ describe('notice', () => {
 
   const paragraphAsset = dom.asset({
     url: '/quantum-html.css',
-    filename: path.join(__dirname, '../../../../quantum-html/assets/quantum-html.css'),
+    filename: path.join(__dirname, '../../../node_modules/quantum-html/assets/quantum-html.css'),
     shared: true
   })
 

--- a/quantum-api/test/files/fileTransform.spec.um
+++ b/quantum-api/test/files/fileTransform.spec.um
@@ -37,8 +37,9 @@
     @changelogList
       @changelog 0.1.0
         @description: Version 0.1.0
-        @change added
-          @description: Api added
+        @entry
+          @change added
+            @description: Api added
         @entry
           @header test-language-1
             @function test1
@@ -132,8 +133,9 @@
       @changelog 0.1.0
         @description: Version 0.1.0
         @group ApiName
-          @change added
-            @description: Api added
+          @entry
+            @change added
+              @description: Api added
           @entry
             @header test-language-1
               @function test2
@@ -233,8 +235,9 @@
       @changelog 0.1.0
         @description: Version 0.1.0
         @group ApiName
-          @change added
-            @description: Api added
+          @entry
+            @change added
+              @description: Api added
           @entry
             @header test-language-1
               @function test3
@@ -376,8 +379,9 @@
             @description: Function updated
       @changelog 0.1.0
         @description: Version 0.1.0
-        @change added
-          @description: Api added
+        @entry
+          @change added
+            @description: Api added
         @entry
           @header test-language-1
             @function test4
@@ -471,8 +475,9 @@
             @description: Function updated
       @changelog 0.1.0
         @description: Version 0.1.0
-        @change added
-          @description: Api added
+        @entry
+          @change added
+            @description: Api added
         @entry
           @header test-language-1
             @function test5
@@ -499,8 +504,9 @@
   @output
     @changelogList
       @changelog 0.1.0
-        @change added
-          @description: Api does something
+        @entry
+          @change added
+            @description: Api does something
         @entry
           @header test-language-1
             @function test6
@@ -560,8 +566,9 @@
   @output
     @changelogList
       @changelog 0.1.0
-        @change added
-          @description: Api does something
+        @entry
+          @change added
+            @description: Api does something
         @entry
           @header test-language-1
             @function test

--- a/quantum-api/test/languages/javascript/changelog.spec.js
+++ b/quantum-api/test/languages/javascript/changelog.spec.js
@@ -156,6 +156,15 @@ describe('changelog', () => {
           .add(dom.create('span').class('qm-api-javascript-header-function-arg-type'))
       }
 
+      function propertyHeaderBuilder (selection, transformer) {
+        const name = selection.param(0)
+        return dom.create('span')
+          .class('qm-api-javascript-header-property')
+          .attr('id', name ? name.toLowerCase() : undefined)
+          .add(dom.create('span').class('qm-api-javascript-header-property-name').text(name || ''))
+          .add(dom.create('span').class('qm-api-javascript-header-property-type'))
+      }
+
       function functionBuilder (selection, transformer) {
         const name = selection.param(0)
 
@@ -177,7 +186,11 @@ describe('changelog', () => {
         .class('qm-changelog-javascript-header')
           .add(dom.create('span')
             .class('qm-changelog-javascript-function')
-            .add(header('function', functionBuilder)(quantum.select(selection), transformer))))
+            .add(header('function', functionBuilder)(quantum.select(selection), transformer)))
+          // TODO: Fix in #144
+          .add(dom.create('span')
+            .class('qm-changelog-javascript-arg')
+            .add(header('property', propertyHeaderBuilder)(quantum.select(child1), transformer))))
     })
 
     it('returns nothing when there are no supported entityTypes', () => {
@@ -204,6 +217,15 @@ describe('changelog', () => {
           .add(dom.create('span').class('qm-api-javascript-header-function-arg-name')
             .text(name || ''))
           .add(dom.create('span').class('qm-api-javascript-header-function-arg-type'))
+      }
+
+      function propertyHeaderBuilder (selection, transformer) {
+        const name = selection.param(0)
+        return dom.create('span')
+          .class('qm-api-javascript-header-property')
+          .attr('id', name ? name.toLowerCase() : undefined)
+          .add(dom.create('span').class('qm-api-javascript-header-property-name').text(name || ''))
+          .add(dom.create('span').class('qm-api-javascript-header-property-type'))
       }
 
       function constructorBuilder (selection, transformer) {
@@ -269,7 +291,11 @@ describe('changelog', () => {
         .class('qm-changelog-javascript-header')
           .add(dom.create('span')
             .class('qm-changelog-javascript-constructor')
-            .add(header('constructor', constructorBuilder)(quantum.select(construct), transformer))))
+            .add(header('constructor', constructorBuilder)(quantum.select(construct), transformer)))
+          // TODO: Fix in #144
+          .add(dom.create('span')
+            .class('qm-changelog-javascript-arg')
+            .add(header('property', propertyHeaderBuilder)(quantum.select(child1), transformer))))
     })
   })
 

--- a/quantum-api/test/languages/javascript/examples/constructor-basic.um
+++ b/quantum-api/test/languages/javascript/examples/constructor-basic.um
@@ -18,7 +18,8 @@
         @entry
           @header javascript
             @constructor test
-              @arg arg0 [String]
+              # TODO: Fix in #144
+              # @arg arg0 [String]
               @returns Number
           @change added
             @description: Constructor added

--- a/quantum-api/test/languages/javascript/examples/function-basic.um
+++ b/quantum-api/test/languages/javascript/examples/function-basic.um
@@ -18,7 +18,8 @@
         @entry
           @header javascript
             @function test
-              @arg arg0 [String]
+              # TODO: Fix in #144
+              # @arg arg0 [String]
               @returns Number
           @change added
             @description: Function added

--- a/quantum-api/test/languages/javascript/examples/function-no-return.um
+++ b/quantum-api/test/languages/javascript/examples/function-no-return.um
@@ -17,6 +17,7 @@
         @entry
           @header javascript
             @function test
-              @arg arg0 [String]
+              # TODO: Fix in #144
+              # @arg arg0 [String]
           @change added
             @description: Function added

--- a/quantum-api/test/languages/javascript/examples/function-return-type-change.um
+++ b/quantum-api/test/languages/javascript/examples/function-return-type-change.um
@@ -32,7 +32,8 @@
         @entry
           @header javascript
             @function test
-              @arg arg0 [String]
+              # TODO: Fix in #144
+              # @arg arg0 [String]
               @returns String
           @change updated
             @description: Return type changed to String

--- a/quantum-api/test/languages/javascript/examples/method-basic.um
+++ b/quantum-api/test/languages/javascript/examples/method-basic.um
@@ -18,7 +18,8 @@
         @entry
           @header javascript
             @method test
-              @arg arg0 [String]
+              # TODO: Fix in #144
+              # @arg arg0 [String]
               @returns Number
           @change added
             @description: Method added

--- a/quantum-code-highlight/lib/index.js
+++ b/quantum-code-highlight/lib/index.js
@@ -32,6 +32,7 @@ function code (selection, transform) {
 
 function codeblock (selection, transform) {
   const language = selection.ps()
+
   return dom.create('div')
     .class(`qm-code-highlight-codeblock${language && language !== 'nohighlight' ? ` language-${language}` : ''}`)
     .add(dom.create('pre')

--- a/quantum-core/bin/quantum
+++ b/quantum-core/bin/quantum
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
 require('../lib/cli')()
+

--- a/quantum-core/lib/api.js
+++ b/quantum-core/lib/api.js
@@ -71,6 +71,7 @@ function buildPage (sourceFile, pipeline, config, logger, addLiveReload) {
   const start = Date.now()
   return Promise.resolve(pipeline(sourceFile))
     .then(files => Array.isArray(files) ? files : [files])
+    .then(files => Array.from(new Map(files.map(f => [f.info.dest, f])).values()))
     .map(file => {
       const shouldInjectLiveReloadScript = addLiveReload &&
         file.info.dest.indexOf('.html') === file.info.dest.length - 5

--- a/quantum-diagram/package.json
+++ b/quantum-diagram/package.json
@@ -6,8 +6,8 @@
     "James Smyth <james.smyth@ocado.com>",
     "Charlie Frater <charlie.frater@ocado.com>"
   ],
-  "engines" : { 
-    "node" : ">=6.0.0" 
+  "engines": {
+    "node": ">=6.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/quantum-docs/package.json
+++ b/quantum-docs/package.json
@@ -7,8 +7,8 @@
     "James Smyth <james.smyth@ocado.com>",
     "Charlie Frater <charlie.frater@ocado.com>"
   ],
-  "engines" : {
-    "node" : ">=6.0.0"
+  "engines": {
+    "node": ">=6.0.0"
   },
   "repository": {
     "type": "git",

--- a/quantum-dom/package.json
+++ b/quantum-dom/package.json
@@ -6,8 +6,8 @@
     "James Smyth <james.smyth@ocado.com>",
     "Charlie Frater <charlie.frater@ocado.com>"
   ],
-  "engines" : { 
-    "node" : ">=6.0.0" 
+  "engines": {
+    "node": ">=6.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/quantum-html/lib/index.js
+++ b/quantum-html/lib/index.js
@@ -188,7 +188,9 @@ function buildDOM (options) {
   function transformer (selection) {
     const type = quantum.isSelection(selection) ? selection.type() : undefined
     const entityTransform = transformMap[type] || defaultTransform
-    return entityTransform(selection, transformer, meta) // bootstrap to itself to  make the transformer accessible to children
+    const res = entityTransform(selection, transformer, meta)
+    // if (type === 'codeblock') console.log(res)
+    return res // bootstrap to itself to  make the transformer accessible to children
   }
 
   // the file transform function that turns parsed content into html content

--- a/quantum-html/lib/index.js
+++ b/quantum-html/lib/index.js
@@ -259,11 +259,13 @@ function buildHTML (opts) {
   }
 }
 
-const asset = dom.asset({
-  url: '/quantum-html.css',
-  filename: path.join(__dirname, '../assets/quantum-html.css'),
-  shared: true
-})
+const assets = {
+  css: dom.asset({
+    url: '/quantum-html.css',
+    filename: path.join(__dirname, '../assets/quantum-html.css'),
+    shared: true
+  })
+}
 
 // Match a string that starts with '. ' or any other punctuation (e.g. '! ') so
 // we don't add an extra space
@@ -273,7 +275,7 @@ const whitespaceRegex = /^\s*$/
 
 function paragraphTransform (selection, transformer) {
   const paragraphs = [
-    asset
+    assets.css
   ]
 
   let currentParagraph = void (0)
@@ -355,5 +357,5 @@ module.exports = {
   paragraphTransform,
   prepareTransforms,
   entityTransforms,
-  asset
+  assets
 }

--- a/quantum-html/lib/index.js
+++ b/quantum-html/lib/index.js
@@ -188,9 +188,7 @@ function buildDOM (options) {
   function transformer (selection) {
     const type = quantum.isSelection(selection) ? selection.type() : undefined
     const entityTransform = transformMap[type] || defaultTransform
-    const res = entityTransform(selection, transformer, meta)
-    // if (type === 'codeblock') console.log(res)
-    return res // bootstrap to itself to  make the transformer accessible to children
+    return entityTransform(selection, transformer, meta) // bootstrap to itself to  make the transformer accessible to children
   }
 
   // the file transform function that turns parsed content into html content

--- a/quantum-html/lib/index.js
+++ b/quantum-html/lib/index.js
@@ -259,6 +259,12 @@ function buildHTML (opts) {
   }
 }
 
+const asset = dom.asset({
+  url: '/quantum-html.css',
+  filename: path.join(__dirname, '../assets/quantum-html.css'),
+  shared: true
+})
+
 // Match a string that starts with '. ' or any other punctuation (e.g. '! ') so
 // we don't add an extra space
 const punctationRegex = /^\W\s/
@@ -267,11 +273,7 @@ const whitespaceRegex = /^\s*$/
 
 function paragraphTransform (selection, transformer) {
   const paragraphs = [
-    dom.asset({
-      url: '/quantum-html.css',
-      filename: path.join(__dirname, '../assets/quantum-html.css'),
-      shared: true
-    })
+    asset
   ]
 
   let currentParagraph = void (0)
@@ -352,5 +354,6 @@ module.exports = {
   htmlRenamer,
   paragraphTransform,
   prepareTransforms,
-  entityTransforms
+  entityTransforms,
+  asset
 }

--- a/quantum-html/test/module.spec.js
+++ b/quantum-html/test/module.spec.js
@@ -10,12 +10,12 @@ describe('module', () => {
       'paragraphTransform',
       'prepareTransforms',
       'entityTransforms',
-      'asset'
+      'assets'
     ]
     html.should.be.an('object')
     html.should.have.keys(keys)
     keys
-      .filter(k => k !== 'asset')
+      .filter(k => k !== 'assets')
       .forEach(key => html[key].should.be.a('function'))
   })
 })

--- a/quantum-html/test/module.spec.js
+++ b/quantum-html/test/module.spec.js
@@ -9,10 +9,13 @@ describe('module', () => {
       'htmlRenamer',
       'paragraphTransform',
       'prepareTransforms',
-      'entityTransforms'
+      'entityTransforms',
+      'asset'
     ]
     html.should.be.an('object')
     html.should.have.keys(keys)
-    keys.forEach(key => html[key].should.be.a('function'))
+    keys
+      .filter(k => k !== 'asset')
+      .forEach(key => html[key].should.be.a('function'))
   })
 })

--- a/quantum-template/package.json
+++ b/quantum-template/package.json
@@ -6,8 +6,8 @@
     "James Smyth <james.smyth@ocado.com>",
     "Charlie Frater <charlie.frater@ocado.com>"
   ],
-  "engines" : { 
-    "node" : ">=6.0.0" 
+  "engines": {
+    "node": ">=6.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/quantum-version/lib/lib.js
+++ b/quantum-version/lib/lib.js
@@ -97,10 +97,10 @@ function versionABeforeVersionB (versionA, versionB, versions) {
   return versions.indexOf(versionA) < versions.indexOf(versionB)
 }
 
-/* Processes all @added, @updated, @deprecated and @removed tags for a file */
+/* Processes all @added, @bugfix, @updated, @deprecated and @removed tags for a file */
 function processTags (content, version, versions, file) {
   const tags = quantum.select(content)
-    .selectAll(['added', 'updated', 'deprecated', 'removed'], {recursive: true})
+    .selectAll(['added', 'updated', 'deprecated', 'removed', 'bugfix'], {recursive: true})
     .filter(tag => {
       const tagHasKnownVersion = versions.indexOf(tag.ps()) > -1
 
@@ -129,6 +129,12 @@ function processTags (content, version, versions, file) {
   tags.filter(t => t.type() === 'updated').forEach(updatedTag => {
     if (updatedTag.ps() !== version) {
       updatedTag.remove()
+    }
+  })
+
+  tags.filter(t => t.type() === 'bugfix').forEach(bugfixTag => {
+    if (bugfixTag.ps() !== version) {
+      bugfixTag.remove()
     }
   })
 

--- a/quantum-version/package.json
+++ b/quantum-version/package.json
@@ -6,7 +6,9 @@
     "James Smyth <james.smyth@ocado.com>",
     "Charlie Frater <charlie.frater@ocado.com>"
   ],
-  "engines" : { "node" : ">=6.0.0" },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This could (should?) be split up and reviewed as module-specific parts, I just
didn't want to lose the changes

### Fixes in this PR

- [x] Constructor options don't display in the changelog
- [x] Added arguments do not show in the changelog
- [x] fix changelog icon for bugfix (class is currently `bug-fix` but changelog uses `bugfix`)
- [x] BugFix isn't removed between versions for api sections
- [x] API change descriptions (i.e. deprecated) don't support codeblocks/inline code
- [x] long function definitions overflow for changelog headers

### Potential Non-issues?

- [ ] Versioned examples display in strange order when inlining with `examples/*.um`
    - This is probably due to the fact that the OS orders files in non-semantic version. Could resolve this by using `01.01.01.um` instead of `1.1.1` - less nice to read but prevents the issue happening without having to do any sorting inside `quantum-version`

### TODO

- [ ] Fix the tests